### PR TITLE
ci(dependabot): rm reviewers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,6 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
-    reviewers:
-      - 'VKCOM/vk-sec'
-      - 'VKCOM/vkui-core'
 
   # Maintain dependencies for npm
   - package-ecosystem: 'npm'
@@ -16,9 +13,6 @@ updates:
       interval: 'daily'
     allow:
       - dependency-type: 'direct'
-    reviewers:
-      - 'VKCOM/vk-sec'
-      - 'VKCOM/vkui-core'
 
   # Maintain dependencies for Cargo
   - package-ecosystem: 'cargo'
@@ -27,7 +21,3 @@ updates:
       interval: 'weekly'
     allow:
       - dependency-type: 'indirect'
-    reviewers:
-      - 'VKCOM/vk-sec'
-      - 'VKCOM/vkui-core'
-


### PR DESCRIPTION
GitHub удаляет поле reviewers так как оно дублируется кодовнерством

https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/